### PR TITLE
Add post-processing step to remove empty rows from relationship CSVs

### DIFF
--- a/dumps.Makefile
+++ b/dumps.Makefile
@@ -101,5 +101,7 @@ $(FINAL_DUMPS_DIR)/owlery.owl: $(patsubst %, $(RAW_DUMPS_DIR)/construct_%.owl, $
 
 pdb_csvs: $(FINAL_DUMPS_DIR)/pdb.owl | $(CSV_IMPORTS)
 	$(call log, $@, java $(ROBOT_ARGS) -jar $(OWL2NEOCSV) $< "$(NEO4J2OWL_CONFIG_FILE)" $(CSV_IMPORTS))
+    @echo "=== Cleaning up CSVs: remove leading commas ==="
+	@sed -i '/^,/d' $(CSV_IMPORTS)/relationship_*.csv
 	@echo "=== Print Timer Logs ==="
 	@cat $(LOG_FILE)


### PR DESCRIPTION
## What
This PR appends a `sed -i '/^,/d' relationship_*.csv` invocation to the `pdb_csvs` Make rule. It strips out rows that start with a comma, which otherwise overwrite edge annotation properties and lead to data loss.

## Why
- Empty/leading-comma rows in the `relationship_*.csv` outputs introduce blank edges in the Neo4j import, clobbering existing annotations.
- Cleaning them immediately after generation ensures that only valid, fully-populated rows are ingested.

## How
- Expanded the `pdb_csvs` recipe to, after running the OWL→CSV conversion, echo a cleanup notice and run the `sed` command against `${CSV_IMPORTS}/relationship_*.csv`.
- No separate target was introduced, keeping CSV generation and cleanup in one atomic step.
